### PR TITLE
Replace Apache Commons IO with java.nio

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,10 +82,5 @@
             <version>2.10.10</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>2.6</version>
-        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
The code within ConfigManager.java has been updated, replacing Apache Commons IO with java.nio for file and directory operations. 'commons-io' dependency was also removed from pom.xml. This move makes use of native Java utility for handling files and directories, reducing the need for external dependencies while improving the code robustness.