### PR TITLE
Update spigot-api version to 1.20.5-R0.1-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.17.1-R0.1-SNAPSHOT</version>
+            <version>1.20.5-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
This commit involves an update in the version of spigot-api used in the project. The previous version was 1.17.1-R0.1-SNAPSHOT, and it has been upgraded to improve functionality and compatibility.